### PR TITLE
ks: move release rpm installation to defs

### DIFF
--- a/data/distro-defs.yml
+++ b/data/distro-defs.yml
@@ -7,6 +7,8 @@ centos8stream:
     extras: --mirrorlist=http://mirrorlist.centos.org/?repo=Extras&release=8-stream&arch=$basearch
   needed_repos:
     - |
+        rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
+        dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/{{ data["copr-repo"] }}/ install -y ovirt-release-master
         dnf config-manager --set-enabled powertools || true
   packages-switch: --excludeWeakdeps
   copr-repo: centos-stream-8-x86_64
@@ -27,6 +29,8 @@ c9s:
     crb: --metalink=https://mirrors.centos.org/metalink?repo=centos-crb-$stream&arch=$basearch
   needed_repos:
     - |
+        rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
+        dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/{{ data["copr-repo"] }}/ install -y ovirt-release-master
         dnf config-manager --set-enabled crb || true
   packages-switch: --excludeWeakdeps
   copr-repo: centos-stream-9-x86_64

--- a/data/ovirt-node-ng-image.j2
+++ b/data/ovirt-node-ng-image.j2
@@ -47,9 +47,6 @@ dnf repolist
 
 # Adding upstream oVirt vdsm
 # 1. Install oVirt release file with repositories
-rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
-dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/{{ data["copr-repo"] }}/ install -y ovirt-release-master
-
 
 {%- for addrepo in data["needed_repos"] %}
 {{ addrepo }}


### PR DESCRIPTION
Moving the installation of the release rpm to distro-defs
to make it easier adding support to cbs builds.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>
Change-Id: I73d60ed703753ebc1e8c5c9d3b897d075c973a60