### PR TITLE
Anaconda: point to CentOS Stream docs

### DIFF
--- a/data/ovirt.conf
+++ b/data/ovirt.conf
@@ -38,7 +38,7 @@ req_partition_sizes =
     /boot  1  GiB
 
 [User Interface]
-help_directory = /usr/share/anaconda/help/rhel
+help_directory = /usr/share/anaconda/help/centos
 hidden_spokes = UserSpoke
 
 [Payload]


### PR DESCRIPTION
## Changes introduced with this PR

* Point to CentOS Stream docs ad RHEL documentation is not available anymore in Anaconda.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes