### PR TITLE
tests: fix missing authselect

### DIFF
--- a/scripts/node-setup/node-install.ks.in
+++ b/scripts/node-setup/node-install.ks.in
@@ -4,7 +4,7 @@
 lang en_US.UTF-8
 keyboard --vckeymap=us --xlayouts=''
 timezone Etc/UTC --isUtc
-auth --enableshadow --passalgo=sha512
+authselect select minimal
 selinux --enforcing
 network --bootproto=dhcp --hostname=@HOSTNAME@
 firstboot --reconfig


### PR DESCRIPTION
## Changes introduced with this PR

Testing the iso fails with:

```
pyanaconda.modules.common.errors.installation.SecurityInstallationError:
/usr/sbin/authconfig is missing. Cannot setup authentication.
```

This is due to changes introduced with PR#10.
Updating the installation kickstart accordingly.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes