### PR TITLE
use legacy crypto policy on el9

### DIFF
--- a/data/distro-defs.yml
+++ b/data/distro-defs.yml
@@ -52,6 +52,9 @@ c9s:
     crb: --metalink=https://mirrors.centos.org/metalink?repo=centos-crb-$stream&arch=$basearch
   needed_repos:
     - |
+        dnf install -y crypto-policies-scripts crypto-policies
+        # until https://pagure.io/copr/copr/issue/2106 is fixed
+        update-crypto-policies --set LEGACY
         rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
         dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-9-x86_64/ install -y ovirt-release-master
         dnf config-manager --set-enabled crb || true


### PR DESCRIPTION
Fixes issue #22

## Changes introduced with this PR

Recent openssl dropped support for sha1 algo but COPR and several
other packaging systems are still signing RPMS with sha1.
In order to be able to install RPMs switching from default crypto policy
to legacy one untill RPMS with newer sha signature will be provided.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes