### PR TITLE
build: separate manifests and logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Upload logs and manifests to github
         uses: actions/upload-artifact@v2
         with:
-          name: logs-and-manifests
+          name: "logs-and-manifests${{ matrix.name }}"
           path: |
             exported-artifacts
 


### PR DESCRIPTION
## Changes introduced with this PR

* keep separate manifests and logs for el9 and el8 builds.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y/n] yes