### PR TITLE
Fixed scripts to work for current CentOS Stream/RHEL 9

### DIFF
--- a/scripts/derive-boot-iso.sh
+++ b/scripts/derive-boot-iso.sh
@@ -109,7 +109,19 @@ modify_bootloader() {
 
 create_iso() {
   echo "[4/4] Creating new ISO"
-  local volid=$(isoinfo -d -i $BOOTISO | grep "Volume id" | cut -d ":" -f2 | sed "s/^ //")
+  local volid
+  if command -v isoinfo &> /dev/null
+  then
+      echo "Using isoinfo"
+      volid=$(isoinfo -d -i "${BOOTISO}" | grep "Volume id" | cut -d ":" -f2 | sed "s/^ //")
+  elif command -v xorriso &> /dev/null
+  then
+      echo "Using xorriso"
+      volid=$(xorriso -indev CentOS-Stream-9-latest-x86_64-boot.iso 2>&1 | grep "Volume id" |cut -d ":" -f2 | sed "s/^ //"|sed  "s/'//g")
+  else
+      echo "Error - Couldn't find either isoinfo nor xorriro. Quiting..."
+      exit 1
+  fi
   rm -rvf $TMPDIR/tmp*
   mkisofs -J -T -U \
       -joliet-long \


### PR DESCRIPTION
derive-boot-iso.sh script previously used now deprecated isoinfo.

On a CentOS Stream/RHEL 9 system where the package that provided
this command was removed due to being deprecated, this caused to
produce broken builds.

This patch adds code to detect the situation in which the isoinfo
command is not available, and try the xorriso command instead.

If none of the two commands are available the script will now fail.

Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Fixed the issue with build system silently generating broken builds on CentOS Stream/RHEL 9 system with the missing isoinfo command due to it being deprecated.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]