### PR TITLE
Fixed a use of constant boot image name instead of a parameter

### DIFF
--- a/scripts/derive-boot-iso.sh
+++ b/scripts/derive-boot-iso.sh
@@ -117,7 +117,7 @@ create_iso() {
   elif command -v xorriso &> /dev/null
   then
       echo "Using xorriso"
-      volid=$(xorriso -indev CentOS-Stream-9-latest-x86_64-boot.iso 2>&1 | grep "Volume id" |cut -d ":" -f2 | sed "s/^ //"|sed  "s/'//g")
+      volid=$(xorriso -indev "${BOOTISO}" 2>&1 | grep "Volume id" |cut -d ":" -f2 | sed "s/^ //"|sed  "s/'//g")
   else
       echo "Error - Couldn't find either isoinfo nor xorriro. Quiting..."
       exit 1


### PR DESCRIPTION
Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Use parametric boot image name instead of constant CentOS Stream 9 one

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]