### PR TITLE
product-img: override alma/rocky anaconda

### DIFF
--- a/data/ovirt.alma.el9.conf
+++ b/data/ovirt.alma.el9.conf
@@ -1,0 +1,47 @@
+# Anaconda configuration file for oVirt Node Next.
+#
+# oVirt Node is using the image installation. The presence of a kickstart
+# file with the liveimg command in it is necessary. Otherwise, Anaconda
+# fallbacks to the package installation. During the image installation,
+# SourceSpoke and SoftwareSelectionSpoke are hidden by default.
+#
+
+# This file overrides /etc/anaconda/product.d/ovirt.conf shipped within anaconda rpm.
+
+[Product]
+# product name as defined at install.img
+# at .buildstamp were we define
+# Product=oVirt Node Next
+# Variant=ovirt-node
+product_name = oVirt Node Next
+
+[Base Product]
+product_name = AlmaLinux
+
+[Storage]
+default_scheme = LVM_THINP
+default_partitioning =
+    /              (min 6 GiB)
+    /home          (size 1 GiB)
+    /tmp           (size 1 GiB)
+    /var           (size 5 GiB)
+    /var/crash     (size 10 GiB)
+    /var/log       (size 8 GiB)
+    /var/log/audit (size 2 GiB)
+    /var/tmp       (size 10 GiB)
+    swap
+
+[Storage Constraints]
+root_device_types = LVM_THINP
+must_not_be_on_root = /var
+req_partition_sizes =
+    /var     5  GiB
+    /var/tmp 10 GiB
+    /boot    1  GiB
+
+[User Interface]
+help_directory = /usr/share/anaconda/help/rhel
+hidden_spokes = UserSpoke
+
+[Payload]
+default_source = CLOSEST_MIRROR

--- a/data/ovirt.rocky.el9.conf
+++ b/data/ovirt.rocky.el9.conf
@@ -1,0 +1,47 @@
+# Anaconda configuration file for oVirt Node Next.
+#
+# oVirt Node is using the image installation. The presence of a kickstart
+# file with the liveimg command in it is necessary. Otherwise, Anaconda
+# fallbacks to the package installation. During the image installation,
+# SourceSpoke and SoftwareSelectionSpoke are hidden by default.
+#
+
+# This file overrides /etc/anaconda/product.d/ovirt.conf shipped within anaconda rpm.
+
+[Product]
+# product name as defined at install.img
+# at .buildstamp were we define
+# Product=oVirt Node Next
+# Variant=ovirt-node
+product_name = oVirt Node Next
+
+[Base Product]
+product_name = Rocky
+
+[Storage]
+default_scheme = LVM_THINP
+default_partitioning =
+    /              (min 6 GiB)
+    /home          (size 1 GiB)
+    /tmp           (size 1 GiB)
+    /var           (size 5 GiB)
+    /var/crash     (size 10 GiB)
+    /var/log       (size 8 GiB)
+    /var/log/audit (size 2 GiB)
+    /var/tmp       (size 10 GiB)
+    swap
+
+[Storage Constraints]
+root_device_types = LVM_THINP
+must_not_be_on_root = /var
+req_partition_sizes =
+    /var     5  GiB
+    /var/tmp 10 GiB
+    /boot    1  GiB
+
+[User Interface]
+help_directory = /usr/share/anaconda/help/rhel
+hidden_spokes = UserSpoke
+
+[Payload]
+default_source = CLOSEST_MIRROR

--- a/scripts/create-product-img.sh
+++ b/scripts/create-product-img.sh
@@ -26,7 +26,13 @@ cp "$SRCDIR"/sidebar-logo.png "$PIXMAPDIR/"
 if [[ -n $SHIP_OVIRT_CONF ]]; then
     product_conf_dir=$PRDDIR/etc/anaconda/product.d
     mkdir -p $product_conf_dir
-    cp $DATADIR/ovirt$(rpm --eval "%dist").conf $product_conf_dir/ovirt.conf
+    if [ "$(rpm --eval %{almalinux})" == "9" ] ; then
+      cp $DATADIR/ovirt.alma.el9.conf $product_conf_dir/ovirt.conf
+    elif [ "$(rpm --eval %{rocky})" == "9" ] ; then
+      cp $DATADIR/ovirt.rocky.el9.conf $product_conf_dir/ovirt.conf
+    else
+      cp $DATADIR/ovirt$(rpm --eval "%dist").conf $product_conf_dir/ovirt.conf
+    fi
 fi
 
 if [[ -n $SSG_TARGET_XML ]]; then


### PR DESCRIPTION
## Changes introduced with this PR

previously we were overriding centos stream's anaconda configuration
also on Alma and Rocky. This caused EFI bootloader configuration to be
installed within the wrong path.
This patch fixes this behavior by overriding the proper distribution
specific configuration.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y