### PR TITLE
build: Increased build timeout to 2 hours

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           mount --bind /lib/modules/$(uname -r) /host/modules
 
   build-matrix:
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
1 hour seems to be not enough in some cases, causing good builds
to be interrupted and cancelled in the middle.

Signed-off-by: Lev Veyde <lveyde@redhat.com>

## Changes introduced with this PR

* Increased build timeout to 2 hours, since 1 hour seems to be not enough.

## Are you the owner of the code you are sending in, or do you have permission of the owner?

[y]