### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: ovirt/checkout-action@main
 
       - name: Build
         env:
@@ -101,7 +101,7 @@ jobs:
           keep_files_count: 20
 
       - name: Upload logs and manifests to github
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "logs-and-manifests${{ matrix.name }}"
           path: |
@@ -120,7 +120,7 @@ jobs:
       - build-matrix
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: ovirt/checkout-action@main
       - name: Add a comment about successful job and close issue
         run: |
           set -e
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: ovirt/checkout-action@main
       - name: Add a comment about failed job
         run: |
           set -e


### PR DESCRIPTION
## Changes introduced with this PR

Fixes:
> Node.js 16 actions are deprecated.
> Please update the following actions to use Node.js 20:
> actions/checkout@v3,
> actions/upload-artifact@v3

Fixes issue # (delete if not relevant)

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y