### PR TITLE
Dropping el8stream builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
   set-kernel:
     strategy:
       matrix:
-        name: [el8, el9]
+        name: [el9]
     runs-on: [image-builders, "${{ matrix.name }}"]
     steps:
       - name: mount /host/modules
@@ -47,8 +47,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: el8
-            container-name: el8stream
           - name: el9
             container-name: el9stream
     runs-on: [image-builders, "${{ matrix.name }}"]


### PR DESCRIPTION
Since CentOS Stream 8 is now EOL and repos moved to vault the el8 build no longer works. Dropping it from configuration, but keeping the matrix structure so that it can be reintroduced (e.g. on stable RHEL clones or whatnot)

