### PR TITLE
Turn off daily build and build on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,11 @@ on:
       checkiso:
         description: set to anything to verify the ISO
         required: false
-  push:
-    branches: [master]
-  schedule:
-    # Running every morning in EMEA timezone
-    - cron: '0 6 * * *'
+  # push:
+  #   branches: [master]
+  # schedule:
+  #   # Running every morning in EMEA timezone
+  #   - cron: '0 6 * * *'
 
 jobs:
   set-kernel:


### PR DESCRIPTION
Daily build are currently broken and there's a number of changes required to get things to work properly so turning off build on push as well.

workflow_dispatch is still enabled for manual builds


## Changes introduced with this PR

* turns off build schedule for the moment

* turns off build on push

* workflow_dispatch is still enabled for manual build when ready

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes