### PR TITLE
Add vscode devcontainer support

### DIFF
--- a/.devcontainer/almalinux9/Dockerfile
+++ b/.devcontainer/almalinux9/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/ovirt/buildcontainer:almalinux9

--- a/.devcontainer/almalinux9/devcontainer.json
+++ b/.devcontainer/almalinux9/devcontainer.json
@@ -1,0 +1,26 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"runArgs": [
+		"--ulimit=nofile=262144:262144",
+		"--privileged",
+		"--device=/dev/kvm"
+		
+	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	},
+	"hostRequirements": {
+		"memory": "4gb"
+	},
+	"mounts": [
+		"type=bind,source=/home/${localEnv:USER}/.ssh,target=/root/.ssh,readonly",
+        "type=bind,source=/lib/modules,target=/lib/modules,readonly"
+	],
+	"postCreateCommand": "ln -s /lib/modules/$(uname -r)/kernel /kernel"
+}

--- a/.devcontainer/almalinux9/devcontainer.json
+++ b/.devcontainer/almalinux9/devcontainer.json
@@ -4,9 +4,7 @@
 	},
 	"runArgs": [
 		"--ulimit=nofile=262144:262144",
-		"--privileged",
-		"--device=/dev/kvm"
-		
+		"--privileged"	
 	],
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/almalinux9/devcontainer.json
+++ b/.devcontainer/almalinux9/devcontainer.json
@@ -18,7 +18,7 @@
 	},
 	"mounts": [
 		"type=bind,source=/home/${localEnv:USER}/.ssh,target=/root/.ssh,readonly",
-        "type=bind,source=/lib/modules,target=/lib/modules,readonly"
+		"type=bind,source=/lib/modules,target=/lib/modules,readonly"
 	],
 	"postCreateCommand": "ln -s /lib/modules/$(uname -r)/kernel /kernel"
 }

--- a/.devcontainer/el9stream/Dockerfile
+++ b/.devcontainer/el9stream/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/ovirt/buildcontainer:el9stream

--- a/.devcontainer/el9stream/devcontainer.json
+++ b/.devcontainer/el9stream/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"runArgs": [
+		"--ulimit=nofile=262144:262144",
+		"--privileged",
+		"--device=/dev/kvm"
+		
+	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	},
+	"hostRequirements": {
+		"memory": "4gb"
+	},
+	"mounts": [
+		"type=bind,source=${localWorkspaceFolder},target=/work",
+		"type=bind,source=/home/${localEnv:USER}/.ssh,target=/root/.ssh,readonly",
+        "type=bind,source=/lib/modules,target=/lib/modules,readonly"
+	],
+	"postCreateCommand": "ln -s /lib/modules/$(uname -r)/kernel /kernel"
+}

--- a/.devcontainer/el9stream/devcontainer.json
+++ b/.devcontainer/el9stream/devcontainer.json
@@ -4,9 +4,7 @@
 	},
 	"runArgs": [
 		"--ulimit=nofile=262144:262144",
-		"--privileged",
-		"--device=/dev/kvm"
-		
+		"--privileged"	
 	],
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/el9stream/devcontainer.json
+++ b/.devcontainer/el9stream/devcontainer.json
@@ -17,7 +17,6 @@
 		"memory": "4gb"
 	},
 	"mounts": [
-		"type=bind,source=${localWorkspaceFolder},target=/work",
 		"type=bind,source=/home/${localEnv:USER}/.ssh,target=/root/.ssh,readonly",
         "type=bind,source=/lib/modules,target=/lib/modules,readonly"
 	],

--- a/.devcontainer/el9stream/devcontainer.json
+++ b/.devcontainer/el9stream/devcontainer.json
@@ -18,7 +18,7 @@
 	},
 	"mounts": [
 		"type=bind,source=/home/${localEnv:USER}/.ssh,target=/root/.ssh,readonly",
-        "type=bind,source=/lib/modules,target=/lib/modules,readonly"
+		"type=bind,source=/lib/modules,target=/lib/modules,readonly"
 	],
 	"postCreateCommand": "ln -s /lib/modules/$(uname -r)/kernel /kernel"
 }


### PR DESCRIPTION
This PR adds support for 2 dev containers.
almalinux9 uses the ovirt/buildcontainer:almalinux9 el9stream uses the ovirt/buildcontainer:el9stream

This matches what the github workflow uses for builds.


## Changes introduced with this PR

* adds support for vscode devcontainers to make it easier to do development

* 1 for almalinux9 and the other for centos9 stream

*

## Are you the owner of the code you are sending in, or do you have permission of the owner?

yes