### PR TITLE
Add build support for alma 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,8 @@ jobs:
     strategy:
       matrix:
         name: [el9]
-    runs-on: [image-builders, "${{ matrix.name }}"]
+    # runs-on: [image-builders, "${{ matrix.name }}"]
+    runs-on: [self-hosted]
     steps:
       - name: mount /host/modules
         run: |
@@ -47,9 +48,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: el9
+          - name: c9s
             container-name: el9stream
-    runs-on: [image-builders, "${{ matrix.name }}"]
+          - name: alma9
+            container-name: almalinux9
+    # runs-on: [image-builders, "${{ matrix.name }}"]
+    runs-on: [self-hosted]
     needs: set-kernel
     container:
       image: quay.io/ovirt/buildcontainer:${{ matrix.container-name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       image: quay.io/ovirt/buildcontainer:${{ matrix.container-name }}
       volumes:
         - /host/modules:/host/modules
-      options: --privileged
+      options: --privileged --ulimit=nofile=262144:262144
 
     steps:
       - name: Checkout

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,3 +54,22 @@ export SUPERMIN_MODULES="/usr/lib/modules/$(uname -r)"
 export CHECK_ISO="True"
 ./build.sh
 ```
+
+## Testing a change locally using vscode devcontainers
+
+Note: The devcontainer itself needs to run on a RHEL-like system (eg. AlmaLinux 9 etc). The build cannot be (currently) performed on an Ubuntu system. Ubuntu users should use the remote-ssh vscode extension and 
+connect to an EL9 type VM for development purposes.
+
+The devcontainer allows you to select the system you want to build. Currently AlmaLinux 9 or Centos 9 Stream. This is currently required due to the way the build.sh script determines the environment type and
+is subject to change in the future to simplify things.
+
+From vscode, if you have the devcontainer extension installed you will be prompted to reopen in a dev container - select almalinux9 if that's what you want to build or one of the other options. You should select this option or press <F1> and search for devcontainer and reopen in container.
+Once the container has been built and running you should create a bash shell via the '+' on the lower right hand side of the screen.
+
+Once bash is open you can :
+
+```bash
+./build.sh
+```
+
+Note: vscode will tell you that the VM has opened a remote access port (eg 5900). You can use something like vncviewer to connect to that port and watch the build in real-time. 

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,7 +69,7 @@ data/%.ks: data/%.j2
 
 LMC ?= livemedia-creator
 %.squashfs.img: data/%.ks @BOOTISO@
-	$(LMC) $(LMCOPTS) --vcpus=$(LMC_CPUS) --ram=$(LMC_MEM) --kernel-args="ipv6.disable=1" --make-pxe-live --nomacboot --iso @BOOTISO@ --ks $< --resultdir build --tmp @TMPDIR@
+	$(LMC) $(LMCOPTS) --live-rootfs-size=5 --vcpus=$(LMC_CPUS) --ram=$(LMC_MEM) --kernel-args="ipv6.disable=1" --make-pxe-live --nomacboot --iso @BOOTISO@ --ks $< --resultdir build --tmp @TMPDIR@
 	mv -v build/*squash* "$@"
 	ls -l *squash*
 	file *squash*

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,7 @@ offline-installation-iso: product.img
 			   bash scripts/create-nightly-boot-iso.sh
 
 iso: product.img @BOOTISO@ $(SQUASHFSFILENAME)
-	scripts/derive-boot-iso.sh $(BOOTISO) $(SQUASHFSFILENAME) "ovirt-node-ng-installer-$(PACKAGE_VERSION)-`date +%Y%m%d%H``rpm --eval %{dist}`.iso"
+	scripts/derive-boot-iso.sh $(BOOTISO) $(SQUASHFSFILENAME) "ovirt-node-ng-installer-$(PACKAGE_VERSION)-`date +%Y%m%d%H`.$(DISTRO).iso"
 
 @BOOTISO@:
 	curl $(CURLOPTS) -O $(BOOTISOURL)

--- a/data/distro-defs.yml
+++ b/data/distro-defs.yml
@@ -78,7 +78,7 @@ alma9:
         rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
         dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-9-x86_64/ install -y ovirt-release-master
         dnf config-manager --set-enabled crb || true
-  packages-switch: --excludeWeakdeps
+  packages-switch: --exclude-weakdeps
   packages:
     - dracut-live
     - centos-stream-repos

--- a/data/distro-defs.yml
+++ b/data/distro-defs.yml
@@ -56,7 +56,7 @@ c9s:
         rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
         dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-9-x86_64/ install -y ovirt-release-master
         dnf config-manager --set-enabled crb || true
-  packages-switch: --excludeWeakdeps
+  packages-switch: --exclude-weakdeps
   packages:
     - dracut-live
     - centos-stream-repos


### PR DESCRIPTION
Fixes issue #49

Notes: While this closes Issue 49, because the almalinux node builds and boots OK, there are still a number of other issues when integrating into the environment - this is due to the engine forcing the addition of centos repos and this needs to be addressed via the engine.

I have validated build with my own self-hosted runner running on the almalinux9 node. I have installed the self-hosted engine on the ovirt node after some creative  disabling of some centos repositories.

## Changes introduced with this PR

* changes to self-hosted runners

* added almalinux9 node build

* fixed Centos 9 Stream build so that it now also works again (bug in pylorax that is avoided with better livemedia-creator options)
*  Added some documentation of how to perform local builds using vscode devcontainers

## Are you the owner of the code you are sending in, or do you have permission of the owner?

y